### PR TITLE
Add AI email assistant

### DIFF
--- a/.github/workflows/email-agent.yml
+++ b/.github/workflows/email-agent.yml
@@ -35,7 +35,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GMAIL_TOKEN_JSON: ${{ secrets.GMAIL_TOKEN_JSON }}
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
-          NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
+          NOTION_PAGE_ID: ${{ secrets.NOTION_PAGE_ID }}
           # CHECK_HOURS covers the window since the last run.
           # With 3x daily (~8h apart), 8 hours with slight overlap is safe.
           CHECK_HOURS: '8'

--- a/.github/workflows/email-agent.yml
+++ b/.github/workflows/email-agent.yml
@@ -1,0 +1,36 @@
+name: AI Email Assistant
+
+on:
+  schedule:
+    # Runs every hour — adjust cron to change frequency
+    # Examples:
+    #   Every 30 min:  '*/30 * * * *'
+    #   Every 2 hours: '0 */2 * * *'
+    #   Twice a day:   '0 9,17 * * *'
+    - cron: '0 * * * *'
+  workflow_dispatch:  # Allows manual trigger from GitHub Actions tab
+
+jobs:
+  check-emails:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run email agent
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GMAIL_TOKEN_JSON: ${{ secrets.GMAIL_TOKEN_JSON }}
+          CHECK_HOURS: '1'
+        run: python agent.py

--- a/.github/workflows/email-agent.yml
+++ b/.github/workflows/email-agent.yml
@@ -1,17 +1,19 @@
-name: AI Email Assistant
+name: AI Email Triage
 
 on:
   schedule:
-    # Runs every hour — adjust cron to change frequency
-    # Examples:
-    #   Every 30 min:  '*/30 * * * *'
-    #   Every 2 hours: '0 */2 * * *'
-    #   Twice a day:   '0 9,17 * * *'
-    - cron: '0 * * * *'
+    # Runs 3x daily — times below are UTC. Adjust to match your timezone.
+    # Examples for US Eastern (ET = UTC-5 in winter, UTC-4 in summer):
+    #   7 AM ET  -> 12:00 UTC
+    #   12 PM ET -> 17:00 UTC
+    #   6 PM ET  -> 23:00 UTC
+    - cron: '0 12 * * *'
+    - cron: '0 17 * * *'
+    - cron: '0 23 * * *'
   workflow_dispatch:  # Allows manual trigger from GitHub Actions tab
 
 jobs:
-  check-emails:
+  triage-emails:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -28,9 +30,13 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Run email agent
+      - name: Run email triage agent
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GMAIL_TOKEN_JSON: ${{ secrets.GMAIL_TOKEN_JSON }}
-          CHECK_HOURS: '1'
+          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
+          # CHECK_HOURS covers the window since the last run.
+          # With 3x daily (~8h apart), 8 hours with slight overlap is safe.
+          CHECK_HOURS: '8'
         run: python agent.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Gmail OAuth credentials — never commit these
+credentials.json
+token.json
+
+# Environment files
+.env
+.env.*
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+venv/

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,220 @@
+import os
+import base64
+import json
+from email.mime.text import MIMEText
+from google.oauth2.credentials import Credentials
+from google.auth.transport.requests import Request
+from googleapiclient.discovery import build
+import anthropic
+from datetime import datetime, timezone, timedelta
+
+SCOPES = [
+    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.send',
+]
+
+
+def get_gmail_service():
+    creds = None
+
+    token_json = os.environ.get('GMAIL_TOKEN_JSON')
+    if token_json:
+        creds = Credentials.from_authorized_user_info(json.loads(token_json), SCOPES)
+    elif os.path.exists('token.json'):
+        creds = Credentials.from_authorized_user_file('token.json', SCOPES)
+
+    if not creds:
+        raise RuntimeError(
+            "No Gmail credentials found. Run auth_setup.py locally to generate token.json, "
+            "then add its contents as the GMAIL_TOKEN_JSON GitHub secret."
+        )
+
+    if creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+        if not os.environ.get('GMAIL_TOKEN_JSON'):
+            with open('token.json', 'w') as f:
+                f.write(creds.to_json())
+
+    return build('gmail', 'v1', credentials=creds)
+
+
+def extract_body(payload):
+    if payload.get('body', {}).get('data'):
+        return base64.urlsafe_b64decode(payload['body']['data']).decode('utf-8', errors='ignore')
+
+    for part in payload.get('parts', []):
+        if part['mimeType'] == 'text/plain':
+            data = part.get('body', {}).get('data', '')
+            if data:
+                return base64.urlsafe_b64decode(data).decode('utf-8', errors='ignore')
+
+    for part in payload.get('parts', []):
+        result = extract_body(part)
+        if result:
+            return result
+
+    return ''
+
+
+def get_recent_emails(service, hours=1):
+    after = int((datetime.now(timezone.utc) - timedelta(hours=hours)).timestamp())
+    query = f'is:unread after:{after} -category:promotions -category:social -category:updates'
+
+    results = service.users().messages().list(userId='me', q=query, maxResults=25).execute()
+    messages = results.get('messages', [])
+
+    emails = []
+    for msg in messages:
+        full = service.users().messages().get(userId='me', id=msg['id'], format='full').execute()
+        headers = {h['name']: h['value'] for h in full['payload']['headers']}
+
+        emails.append({
+            'id': msg['id'],
+            'thread_id': full['threadId'],
+            'subject': headers.get('Subject', '(no subject)'),
+            'from': headers.get('From', ''),
+            'to': headers.get('To', ''),
+            'date': headers.get('Date', ''),
+            'body': extract_body(full['payload'])[:3000],
+            'list_unsubscribe': headers.get('List-Unsubscribe', ''),
+            'list_id': headers.get('List-ID', ''),
+            'precedence': headers.get('Precedence', ''),
+        })
+
+    return emails
+
+
+def classify_and_draft(client, email):
+    prompt = f"""You are an email assistant. Analyze this email and determine if it is an important
+email that requires a personal reply from the recipient.
+
+Email details:
+- From: {email['from']}
+- Subject: {email['subject']}
+- Date: {email['date']}
+- List-Unsubscribe header: {email['list_unsubscribe'] or 'None'}
+- List-ID header: {email['list_id'] or 'None'}
+- Precedence header: {email['precedence'] or 'None'}
+- Body:
+{email['body']}
+
+Classify this email and respond with a JSON object only — no extra text:
+{{
+  "needs_reply": true or false,
+  "reason": "brief explanation",
+  "draft_reply": "full draft reply text if needs_reply is true, otherwise null"
+}}
+
+Mark needs_reply as FALSE for:
+- Newsletters, digests, subscription emails
+- Marketing or promotional content
+- Automated notifications (receipts, order updates, shipping, bank alerts)
+- Social media notifications
+- Emails with List-Unsubscribe, List-ID, or Precedence: bulk headers
+- Senders containing "noreply", "no-reply", "donotreply", "notifications", "alerts"
+- Spam or unsolicited bulk email
+
+Mark needs_reply as TRUE for:
+- Direct personal email from a real person to the recipient
+- A colleague, client, or partner asking a question or waiting on something
+- Meeting requests or scheduling emails that need confirmation
+- Business emails requiring a decision or action
+
+If needs_reply is true, write a professional, helpful draft reply in first person.
+Keep it concise and natural — leave placeholders like [NAME] only where truly needed."""
+
+    response = client.messages.create(
+        model='claude-opus-4-6',
+        max_tokens=1024,
+        messages=[{'role': 'user', 'content': prompt}],
+    )
+
+    try:
+        return json.loads(response.content[0].text)
+    except json.JSONDecodeError:
+        return {'needs_reply': False, 'reason': 'Could not parse response', 'draft_reply': None}
+
+
+def create_draft(service, email, draft_text):
+    message = MIMEText(draft_text)
+    message['To'] = email['from']
+    message['Subject'] = f"Re: {email['subject']}"
+    message['In-Reply-To'] = email['id']
+    message['References'] = email['id']
+
+    raw = base64.urlsafe_b64encode(message.as_bytes()).decode('utf-8')
+
+    draft = service.users().drafts().create(
+        userId='me',
+        body={'message': {'raw': raw, 'threadId': email['thread_id']}},
+    ).execute()
+
+    return draft['id']
+
+
+def send_notification(service, user_email, drafted_emails):
+    lines = []
+    for i, item in enumerate(drafted_emails, 1):
+        lines.append(f"{i}. From:    {item['from']}")
+        lines.append(f"   Subject: {item['subject']}")
+        lines.append('')
+
+    body = (
+        f"Your AI email assistant created {len(drafted_emails)} draft reply(s) for your review.\n\n"
+        + '\n'.join(lines)
+        + "Review and send your drafts here:\nhttps://mail.google.com/mail/u/0/#drafts\n\n"
+        + f"---\nRun completed at {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}"
+    )
+
+    message = MIMEText(body)
+    message['To'] = user_email
+    message['From'] = user_email
+    message['Subject'] = f"[AI Assistant] {len(drafted_emails)} draft reply(s) ready"
+
+    raw = base64.urlsafe_b64encode(message.as_bytes()).decode('utf-8')
+    service.users().messages().send(userId='me', body={'raw': raw}).execute()
+
+
+def main():
+    api_key = os.environ.get('ANTHROPIC_API_KEY')
+    if not api_key:
+        raise ValueError('ANTHROPIC_API_KEY environment variable is not set.')
+
+    client = anthropic.Anthropic(api_key=api_key)
+    service = get_gmail_service()
+
+    profile = service.users().getProfile(userId='me').execute()
+    user_email = profile['emailAddress']
+    print(f'Checking emails for {user_email}...')
+
+    hours = int(os.environ.get('CHECK_HOURS', '1'))
+    emails = get_recent_emails(service, hours=hours)
+    print(f'Found {len(emails)} unread emails to analyse')
+
+    drafted_emails = []
+
+    for email in emails:
+        print(f"  Analysing: {email['subject'][:60]}")
+        result = classify_and_draft(client, email)
+
+        if result.get('needs_reply') and result.get('draft_reply'):
+            draft_id = create_draft(service, email, result['draft_reply'])
+            drafted_emails.append({
+                'from': email['from'],
+                'subject': email['subject'],
+                'draft_id': draft_id,
+            })
+            print(f"    -> Draft created")
+        else:
+            print(f"    -> Skipped ({result.get('reason', 'no reply needed')})")
+
+    if drafted_emails:
+        send_notification(service, user_email, drafted_emails)
+        print(f'\nDone. {len(drafted_emails)} draft(s) created. Notification sent to {user_email}.')
+    else:
+        print('\nDone. No drafts needed this run.')
+
+
+if __name__ == '__main__':
+    main()

--- a/agent.py
+++ b/agent.py
@@ -1,7 +1,10 @@
 import os
+import re
 import base64
 import json
+import requests
 from email.mime.text import MIMEText
+from email.utils import parsedate_to_datetime
 from google.oauth2.credentials import Credentials
 from google.auth.transport.requests import Request
 from googleapiclient.discovery import build
@@ -9,10 +12,32 @@ import anthropic
 from datetime import datetime, timezone, timedelta
 
 SCOPES = [
-    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/gmail.modify',
     'https://www.googleapis.com/auth/gmail.compose',
     'https://www.googleapis.com/auth/gmail.send',
 ]
+
+# 7 triage categories with display labels
+CATEGORIES = {
+    'needs_reply':   'Needs Reply',
+    'needs_action':  'Needs Action',
+    'waiting_for':   'Waiting For',
+    'delegate':      'Delegate',
+    'read_later':    'Read Later',
+    'newsletter':    'Newsletter',
+    'no_action':     'No Action',
+}
+
+# Points toward cognitive load score (0-10)
+COGNITIVE_WEIGHTS = {
+    'needs_reply':  3,
+    'needs_action': 2,
+    'delegate':     1,
+    'waiting_for':  1,
+    'read_later':   0,
+    'newsletter':   0,
+    'no_action':    0,
+}
 
 
 def get_gmail_service():
@@ -57,11 +82,11 @@ def extract_body(payload):
     return ''
 
 
-def get_recent_emails(service, hours=1):
+def get_recent_emails(service, hours=8):
     after = int((datetime.now(timezone.utc) - timedelta(hours=hours)).timestamp())
     query = f'is:unread after:{after} -category:promotions -category:social -category:updates'
 
-    results = service.users().messages().list(userId='me', q=query, maxResults=25).execute()
+    results = service.users().messages().list(userId='me', q=query, maxResults=50).execute()
     messages = results.get('messages', [])
 
     emails = []
@@ -85,44 +110,35 @@ def get_recent_emails(service, hours=1):
     return emails
 
 
-def classify_and_draft(client, email):
-    prompt = f"""You are an email assistant. Analyze this email and determine if it is an important
-email that requires a personal reply from the recipient.
+def triage_email(client, email):
+    prompt = f"""You are an expert email triage assistant. Classify this email into exactly one category.
+
+Categories:
+- needs_reply:  A real person sent this directly and expects a personal reply
+- needs_action: Requires a task or decision from you, but no email reply needed
+- waiting_for:  You sent this or are CC'd — you're waiting on the other party
+- delegate:     Should be forwarded to or handled by someone else
+- read_later:   Worth reading for context but no action required
+- newsletter:   Subscribed newsletter, digest, or regular publication
+- no_action:    Automated notification, receipt, alert, spam, or bulk mail
 
 Email details:
 - From: {email['from']}
 - Subject: {email['subject']}
 - Date: {email['date']}
-- List-Unsubscribe header: {email['list_unsubscribe'] or 'None'}
-- List-ID header: {email['list_id'] or 'None'}
-- Precedence header: {email['precedence'] or 'None'}
+- List-Unsubscribe: {email['list_unsubscribe'] or 'None'}
+- List-ID: {email['list_id'] or 'None'}
+- Precedence: {email['precedence'] or 'None'}
 - Body:
 {email['body']}
 
-Classify this email and respond with a JSON object only — no extra text:
+Respond with a JSON object only — no extra text:
 {{
-  "needs_reply": true or false,
-  "reason": "brief explanation",
-  "draft_reply": "full draft reply text if needs_reply is true, otherwise null"
-}}
-
-Mark needs_reply as FALSE for:
-- Newsletters, digests, subscription emails
-- Marketing or promotional content
-- Automated notifications (receipts, order updates, shipping, bank alerts)
-- Social media notifications
-- Emails with List-Unsubscribe, List-ID, or Precedence: bulk headers
-- Senders containing "noreply", "no-reply", "donotreply", "notifications", "alerts"
-- Spam or unsolicited bulk email
-
-Mark needs_reply as TRUE for:
-- Direct personal email from a real person to the recipient
-- A colleague, client, or partner asking a question or waiting on something
-- Meeting requests or scheduling emails that need confirmation
-- Business emails requiring a decision or action
-
-If needs_reply is true, write a professional, helpful draft reply in first person.
-Keep it concise and natural — leave placeholders like [NAME] only where truly needed."""
+  "category": "<one of the 7 categories>",
+  "reason": "one concise sentence",
+  "urgency": "high|medium|low",
+  "draft_reply": "full draft reply if category is needs_reply, otherwise null"
+}}"""
 
     response = client.messages.create(
         model='claude-opus-4-6',
@@ -131,9 +147,23 @@ Keep it concise and natural — leave placeholders like [NAME] only where truly 
     )
 
     try:
-        return json.loads(response.content[0].text)
-    except json.JSONDecodeError:
-        return {'needs_reply': False, 'reason': 'Could not parse response', 'draft_reply': None}
+        raw = response.content[0].text.strip()
+        raw = re.sub(r'^```(?:json)?\s*', '', raw)
+        raw = re.sub(r'\s*```$', '', raw)
+        result = json.loads(raw)
+        if result.get('category') not in CATEGORIES:
+            result['category'] = 'no_action'
+        return result
+    except (json.JSONDecodeError, IndexError):
+        return {'category': 'no_action', 'reason': 'Could not parse response', 'urgency': 'low', 'draft_reply': None}
+
+
+def mark_as_read(service, email_id):
+    service.users().messages().modify(
+        userId='me',
+        id=email_id,
+        body={'removeLabelIds': ['UNREAD']},
+    ).execute()
 
 
 def create_draft(service, email, draft_text):
@@ -153,24 +183,74 @@ def create_draft(service, email, draft_text):
     return draft['id']
 
 
-def send_notification(service, user_email, drafted_emails):
-    lines = []
-    for i, item in enumerate(drafted_emails, 1):
-        lines.append(f"{i}. From:    {item['from']}")
-        lines.append(f"   Subject: {item['subject']}")
-        lines.append('')
+def log_to_notion(token, database_id, email, category, reason, urgency, draft_gmail_url=None):
+    try:
+        dt = parsedate_to_datetime(email['date'])
+        date_iso = dt.astimezone(timezone.utc).isoformat()
+    except Exception:
+        date_iso = datetime.now(timezone.utc).isoformat()
 
-    body = (
-        f"Your AI email assistant created {len(drafted_emails)} draft reply(s) for your review.\n\n"
-        + '\n'.join(lines)
-        + "Review and send your drafts here:\nhttps://mail.google.com/mail/u/0/#drafts\n\n"
-        + f"---\nRun completed at {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}"
+    properties = {
+        'Subject':  {'title':     [{'text': {'content': email['subject'][:2000]}}]},
+        'From':     {'rich_text': [{'text': {'content': email['from'][:2000]}}]},
+        'Category': {'select':    {'name': CATEGORIES[category]}},
+        'Urgency':  {'select':    {'name': urgency.capitalize()}},
+        'Reason':   {'rich_text': [{'text': {'content': reason[:2000]}}]},
+        'Received': {'date':      {'start': date_iso}},
+    }
+
+    if draft_gmail_url:
+        properties['Draft'] = {'url': draft_gmail_url}
+
+    response = requests.post(
+        'https://api.notion.com/v1/pages',
+        headers={
+            'Authorization': f'Bearer {token}',
+            'Content-Type': 'application/json',
+            'Notion-Version': '2022-06-28',
+        },
+        json={'parent': {'database_id': database_id}, 'properties': properties},
+        timeout=10,
     )
+    return response.status_code == 200
 
-    message = MIMEText(body)
+
+def compute_cognitive_load(results):
+    raw = sum(COGNITIVE_WEIGHTS.get(r['category'], 0) for r in results)
+    return min(10, raw)
+
+
+def send_notification(service, user_email, drafted_emails, summary, cognitive_score):
+    load_label = 'Low' if cognitive_score <= 3 else 'Medium' if cognitive_score <= 6 else 'High'
+
+    lines = [
+        f"Cognitive Load: {cognitive_score}/10 ({load_label})",
+        '',
+        'Triage Summary:',
+    ]
+    for key, label in CATEGORIES.items():
+        count = summary.get(key, 0)
+        if count > 0:
+            lines.append(f"  {label}: {count}")
+
+    if drafted_emails:
+        lines += ['', '--- Drafts Ready ---']
+        for i, item in enumerate(drafted_emails, 1):
+            lines.append(f"{i}. From:    {item['from']}")
+            lines.append(f"   Subject: {item['subject']}")
+            lines.append('')
+        lines.append('Review drafts: https://mail.google.com/mail/u/0/#drafts')
+
+    lines.append(f"\n---\nRun completed at {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
+
+    message = MIMEText('\n'.join(lines))
     message['To'] = user_email
     message['From'] = user_email
-    message['Subject'] = f"[AI Assistant] {len(drafted_emails)} draft reply(s) ready"
+    message['Subject'] = (
+        f"[AI Triage] Load {cognitive_score}/10 — "
+        f"{summary.get('needs_reply', 0)} draft(s), "
+        f"{summary.get('needs_action', 0)} action(s)"
+    )
 
     raw = base64.urlsafe_b64encode(message.as_bytes()).decode('utf-8')
     service.users().messages().send(userId='me', body={'raw': raw}).execute()
@@ -181,6 +261,10 @@ def main():
     if not api_key:
         raise ValueError('ANTHROPIC_API_KEY environment variable is not set.')
 
+    notion_token = os.environ.get('NOTION_API_KEY')
+    notion_db = os.environ.get('NOTION_DATABASE_ID')
+    use_notion = bool(notion_token and notion_db)
+
     client = anthropic.Anthropic(api_key=api_key)
     service = get_gmail_service()
 
@@ -188,32 +272,56 @@ def main():
     user_email = profile['emailAddress']
     print(f'Checking emails for {user_email}...')
 
-    hours = int(os.environ.get('CHECK_HOURS', '1'))
+    hours = int(os.environ.get('CHECK_HOURS', '8'))
     emails = get_recent_emails(service, hours=hours)
-    print(f'Found {len(emails)} unread emails to analyse')
+    print(f'Found {len(emails)} unread emails to triage')
 
+    results = []
     drafted_emails = []
+    summary = {k: 0 for k in CATEGORIES}
+    notion_failures = 0
 
     for email in emails:
-        print(f"  Analysing: {email['subject'][:60]}")
-        result = classify_and_draft(client, email)
+        print(f"  Triaging: {email['subject'][:60]}")
+        result = triage_email(client, email)
 
-        if result.get('needs_reply') and result.get('draft_reply'):
+        category = result.get('category', 'no_action')
+        reason = result.get('reason', '')
+        urgency = result.get('urgency', 'low')
+        draft_gmail_url = None
+
+        if category == 'needs_reply' and result.get('draft_reply'):
             draft_id = create_draft(service, email, result['draft_reply'])
-            drafted_emails.append({
-                'from': email['from'],
-                'subject': email['subject'],
-                'draft_id': draft_id,
-            })
-            print(f"    -> Draft created")
+            draft_gmail_url = f"https://mail.google.com/mail/u/0/#drafts/{draft_id}"
+            drafted_emails.append({'from': email['from'], 'subject': email['subject']})
+            print(f"    -> [{CATEGORIES[category]}] Draft created")
         else:
-            print(f"    -> Skipped ({result.get('reason', 'no reply needed')})")
+            print(f"    -> [{CATEGORIES[category]}] {reason}")
 
-    if drafted_emails:
-        send_notification(service, user_email, drafted_emails)
-        print(f'\nDone. {len(drafted_emails)} draft(s) created. Notification sent to {user_email}.')
+        mark_as_read(service, email['id'])
+
+        if use_notion:
+            ok = log_to_notion(notion_token, notion_db, email, category, reason, urgency, draft_gmail_url)
+            if not ok:
+                notion_failures += 1
+
+        summary[category] += 1
+        results.append({'category': category})
+
+    cognitive_score = compute_cognitive_load(results)
+
+    if notion_failures:
+        print(f'Warning: {notion_failures} Notion log(s) failed.')
+
+    if emails:
+        send_notification(service, user_email, drafted_emails, summary, cognitive_score)
+        print(
+            f'\nDone. Cognitive load: {cognitive_score}/10. '
+            f'{len(drafted_emails)} draft(s) created. '
+            f'Notification sent to {user_email}.'
+        )
     else:
-        print('\nDone. No drafts needed this run.')
+        print('\nDone. No new emails this run.')
 
 
 if __name__ == '__main__':

--- a/agent.py
+++ b/agent.py
@@ -4,7 +4,6 @@ import base64
 import json
 import requests
 from email.mime.text import MIMEText
-from email.utils import parsedate_to_datetime
 from google.oauth2.credentials import Credentials
 from google.auth.transport.requests import Request
 from googleapiclient.discovery import build
@@ -183,24 +182,45 @@ def create_draft(service, email, draft_text):
     return draft['id']
 
 
-def log_to_notion(token, database_id, email, category, reason, urgency, draft_gmail_url=None):
-    try:
-        dt = parsedate_to_datetime(email['date'])
-        date_iso = dt.astimezone(timezone.utc).isoformat()
-    except Exception:
-        date_iso = datetime.now(timezone.utc).isoformat()
+def push_briefing_to_notion(token, page_id, action_items, summary, cognitive_score, drafted_count):
+    """Create a single briefing page under a Notion parent page."""
+    load_label = 'Low' if cognitive_score <= 3 else 'Medium' if cognitive_score <= 6 else 'High'
+    now = datetime.now(timezone.utc)
+    title = f"Email Briefing — {now.strftime('%b %-d, %Y %H:%M UTC')}"
 
-    properties = {
-        'Subject':  {'title':     [{'text': {'content': email['subject'][:2000]}}]},
-        'From':     {'rich_text': [{'text': {'content': email['from'][:2000]}}]},
-        'Category': {'select':    {'name': CATEGORIES[category]}},
-        'Urgency':  {'select':    {'name': urgency.capitalize()}},
-        'Reason':   {'rich_text': [{'text': {'content': reason[:2000]}}]},
-        'Received': {'date':      {'start': date_iso}},
-    }
+    # Build page content blocks
+    children = [
+        _notion_heading(f"Cognitive Load: {cognitive_score}/10 ({load_label})"),
+    ]
 
-    if draft_gmail_url:
-        properties['Draft'] = {'url': draft_gmail_url}
+    # Only show categories that need attention
+    actionable = ['needs_reply', 'needs_action', 'delegate', 'waiting_for']
+    for cat in actionable:
+        items = [i for i in action_items if i['category'] == cat]
+        if not items:
+            continue
+        children.append(_notion_heading(f"{CATEGORIES[cat]} ({len(items)})", level=2))
+        for item in items:
+            urgency_tag = f"[{item['urgency'].upper()}]" if item['urgency'] == 'high' else f"[{item['urgency'].capitalize()}]"
+            line = f"{urgency_tag} {item['from']} — {item['subject']}"
+            children.append(_notion_paragraph(line))
+            children.append(_notion_paragraph(f"  ↳ {item['reason']}", italic=True))
+
+    if drafted_count > 0:
+        children.append(_notion_divider())
+        children.append(_notion_paragraph(
+            f"{drafted_count} draft(s) ready → https://mail.google.com/mail/u/0/#drafts"
+        ))
+
+    # Quiet summary at the bottom
+    quiet_total = sum(summary.get(k, 0) for k in ('read_later', 'newsletter', 'no_action'))
+    if quiet_total > 0:
+        children.append(_notion_divider())
+        parts = []
+        for k in ('read_later', 'newsletter', 'no_action'):
+            if summary.get(k, 0) > 0:
+                parts.append(f"{CATEGORIES[k]}: {summary[k]}")
+        children.append(_notion_paragraph(f"Skipped: {', '.join(parts)}"))
 
     response = requests.post(
         'https://api.notion.com/v1/pages',
@@ -209,10 +229,28 @@ def log_to_notion(token, database_id, email, category, reason, urgency, draft_gm
             'Content-Type': 'application/json',
             'Notion-Version': '2022-06-28',
         },
-        json={'parent': {'database_id': database_id}, 'properties': properties},
-        timeout=10,
+        json={
+            'parent': {'page_id': page_id},
+            'properties': {'title': {'title': [{'text': {'content': title}}]}},
+            'children': children[:100],  # Notion API limit
+        },
+        timeout=15,
     )
     return response.status_code == 200
+
+
+def _notion_heading(text, level=1):
+    key = f"heading_{level}"
+    return {key: {'rich_text': [{'text': {'content': text}}]}}
+
+
+def _notion_paragraph(text, italic=False):
+    annotations = {'italic': True} if italic else {}
+    return {'paragraph': {'rich_text': [{'text': {'content': text}, 'annotations': annotations}]}}
+
+
+def _notion_divider():
+    return {'divider': {}}
 
 
 def compute_cognitive_load(results):
@@ -220,35 +258,44 @@ def compute_cognitive_load(results):
     return min(10, raw)
 
 
-def send_notification(service, user_email, drafted_emails, summary, cognitive_score):
+def send_notification(service, user_email, action_items, summary, cognitive_score, drafted_count):
     load_label = 'Low' if cognitive_score <= 3 else 'Medium' if cognitive_score <= 6 else 'High'
 
     lines = [
         f"Cognitive Load: {cognitive_score}/10 ({load_label})",
         '',
-        'Triage Summary:',
     ]
-    for key, label in CATEGORIES.items():
-        count = summary.get(key, 0)
-        if count > 0:
-            lines.append(f"  {label}: {count}")
 
-    if drafted_emails:
-        lines += ['', '--- Drafts Ready ---']
-        for i, item in enumerate(drafted_emails, 1):
-            lines.append(f"{i}. From:    {item['from']}")
-            lines.append(f"   Subject: {item['subject']}")
+    # Only show what needs attention
+    for cat in ('needs_reply', 'needs_action', 'delegate', 'waiting_for'):
+        items = [i for i in action_items if i['category'] == cat]
+        if not items:
+            continue
+        lines.append(f"--- {CATEGORIES[cat]} ({len(items)}) ---")
+        for item in items:
+            tag = item['urgency'].upper() if item['urgency'] == 'high' else item['urgency'].capitalize()
+            lines.append(f"  [{tag}] {item['from']}")
+            lines.append(f"    {item['subject']}")
+            lines.append(f"    {item['reason']}")
             lines.append('')
-        lines.append('Review drafts: https://mail.google.com/mail/u/0/#drafts')
 
-    lines.append(f"\n---\nRun completed at {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
+    if drafted_count > 0:
+        lines.append(f'{drafted_count} draft(s) ready: https://mail.google.com/mail/u/0/#drafts')
+        lines.append('')
+
+    # Quiet counts
+    quiet = {k: summary.get(k, 0) for k in ('read_later', 'newsletter', 'no_action') if summary.get(k, 0) > 0}
+    if quiet:
+        lines.append('Skipped: ' + ', '.join(f"{CATEGORIES[k]}: {v}" for k, v in quiet.items()))
+
+    lines.append(f"\n---\n{datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
 
     message = MIMEText('\n'.join(lines))
     message['To'] = user_email
     message['From'] = user_email
     message['Subject'] = (
         f"[AI Triage] Load {cognitive_score}/10 — "
-        f"{summary.get('needs_reply', 0)} draft(s), "
+        f"{drafted_count} draft(s), "
         f"{summary.get('needs_action', 0)} action(s)"
     )
 
@@ -262,8 +309,8 @@ def main():
         raise ValueError('ANTHROPIC_API_KEY environment variable is not set.')
 
     notion_token = os.environ.get('NOTION_API_KEY')
-    notion_db = os.environ.get('NOTION_DATABASE_ID')
-    use_notion = bool(notion_token and notion_db)
+    notion_page = os.environ.get('NOTION_PAGE_ID')
+    use_notion = bool(notion_token and notion_page)
 
     client = anthropic.Anthropic(api_key=api_key)
     service = get_gmail_service()
@@ -277,9 +324,9 @@ def main():
     print(f'Found {len(emails)} unread emails to triage')
 
     results = []
-    drafted_emails = []
+    action_items = []
+    drafted_count = 0
     summary = {k: 0 for k in CATEGORIES}
-    notion_failures = 0
 
     for email in emails:
         print(f"  Triaging: {email['subject'][:60]}")
@@ -288,36 +335,45 @@ def main():
         category = result.get('category', 'no_action')
         reason = result.get('reason', '')
         urgency = result.get('urgency', 'low')
-        draft_gmail_url = None
 
         if category == 'needs_reply' and result.get('draft_reply'):
-            draft_id = create_draft(service, email, result['draft_reply'])
-            draft_gmail_url = f"https://mail.google.com/mail/u/0/#drafts/{draft_id}"
-            drafted_emails.append({'from': email['from'], 'subject': email['subject']})
+            create_draft(service, email, result['draft_reply'])
+            drafted_count += 1
             print(f"    -> [{CATEGORIES[category]}] Draft created")
         else:
             print(f"    -> [{CATEGORIES[category]}] {reason}")
 
         mark_as_read(service, email['id'])
 
-        if use_notion:
-            ok = log_to_notion(notion_token, notion_db, email, category, reason, urgency, draft_gmail_url)
-            if not ok:
-                notion_failures += 1
+        # Track actionable items for the briefing
+        if category in ('needs_reply', 'needs_action', 'delegate', 'waiting_for'):
+            action_items.append({
+                'category': category,
+                'from': email['from'],
+                'subject': email['subject'],
+                'reason': reason,
+                'urgency': urgency,
+            })
 
         summary[category] += 1
         results.append({'category': category})
 
     cognitive_score = compute_cognitive_load(results)
 
-    if notion_failures:
-        print(f'Warning: {notion_failures} Notion log(s) failed.')
+    if use_notion and emails:
+        ok = push_briefing_to_notion(
+            notion_token, notion_page, action_items, summary, cognitive_score, drafted_count,
+        )
+        if ok:
+            print('Briefing pushed to Notion.')
+        else:
+            print('Warning: Failed to push briefing to Notion.')
 
     if emails:
-        send_notification(service, user_email, drafted_emails, summary, cognitive_score)
+        send_notification(service, user_email, action_items, summary, cognitive_score, drafted_count)
         print(
             f'\nDone. Cognitive load: {cognitive_score}/10. '
-            f'{len(drafted_emails)} draft(s) created. '
+            f'{drafted_count} draft(s) created. '
             f'Notification sent to {user_email}.'
         )
     else:

--- a/auth_setup.py
+++ b/auth_setup.py
@@ -7,6 +7,9 @@ Steps:
 2. Run: python auth_setup.py
 3. Copy the printed token JSON and add it as GMAIL_TOKEN_JSON in GitHub Secrets
 
+NOTE: If you previously ran this script, run it again — the gmail.modify scope
+was added so the agent can mark emails as read.
+
 Requirements: pip install google-auth-oauthlib
 """
 
@@ -14,7 +17,7 @@ import json
 from google_auth_oauthlib.flow import InstalledAppFlow
 
 SCOPES = [
-    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/gmail.modify',
     'https://www.googleapis.com/auth/gmail.compose',
     'https://www.googleapis.com/auth/gmail.send',
 ]

--- a/auth_setup.py
+++ b/auth_setup.py
@@ -1,0 +1,34 @@
+"""
+Run this script ONCE on your local machine to authorise Gmail access.
+It will open a browser for you to log in, then save token.json.
+
+Steps:
+1. Place your credentials.json from Google Cloud Console in this folder
+2. Run: python auth_setup.py
+3. Copy the printed token JSON and add it as GMAIL_TOKEN_JSON in GitHub Secrets
+
+Requirements: pip install google-auth-oauthlib
+"""
+
+import json
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+SCOPES = [
+    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/gmail.compose',
+    'https://www.googleapis.com/auth/gmail.send',
+]
+
+flow = InstalledAppFlow.from_client_secrets_file('credentials.json', SCOPES)
+creds = flow.run_local_server(port=0)
+
+token_json = creds.to_json()
+
+with open('token.json', 'w') as f:
+    f.write(token_json)
+
+print('token.json saved successfully.\n')
+print('=' * 60)
+print('Copy everything below as your GMAIL_TOKEN_JSON GitHub secret:')
+print('=' * 60)
+print(token_json)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+anthropic>=0.40.0
+google-api-python-client>=2.0.0
+google-auth-httplib2>=0.2.0
+google-auth-oauthlib>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ anthropic>=0.40.0
 google-api-python-client>=2.0.0
 google-auth-httplib2>=0.2.0
 google-auth-oauthlib>=1.0.0
+requests>=2.31.0


### PR DESCRIPTION
Adds the AI email triage agent with Gmail, Claude, and Notion integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Runs unattended automation that reads and modifies Gmail (marks unread mail as read and creates drafts/sends notifications) using long-lived OAuth/third-party API credentials, so misclassification or auth mishandling could cause missed emails or unintended inbox changes.
> 
> **Overview**
> Adds a GitHub Actions workflow (`email-agent.yml`) that runs 3x daily (and manually) to execute a new Python `agent.py` email triage job.
> 
> The agent pulls recent unread Gmail messages, uses Anthropic Claude to categorize them (and optionally draft replies), **marks messages as read**, sends a summary notification email, and optionally posts an actionable briefing to Notion when `NOTION_API_KEY`/`NOTION_PAGE_ID` are provided.
> 
> Includes local OAuth bootstrap script (`auth_setup.py`), new Python dependencies (`requirements.txt`), and a `.gitignore` update to prevent committing Gmail credential/token and env files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c206e905d673583da2e2f3523736687eb8c03f8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->